### PR TITLE
Save file in utf-8 explicitly for Windows compat

### DIFF
--- a/phonemizer/backend/espeak.py
+++ b/phonemizer/backend/espeak.py
@@ -127,7 +127,7 @@ class BaseEspeakBackend(BaseBackend):
     def _phonemize_aux(self, text, separator, strip):
         output = []
         for num, line in enumerate(text.split('\n'), start=1):
-            with tempfile.NamedTemporaryFile('w+', delete=False) as data:
+            with tempfile.NamedTemporaryFile('w+', encoding='utf8', delete=False) as data:
                 try:
                     # save the text as a tempfile
                     data.write(line)


### PR DESCRIPTION
When dealing with Chinese characters on Chinese version Windows, the file is saved in CP936 that will make the output not usable (shown and read as umlaut, etc.). Save the temp file for espeak backend in utf-8 explicitly to resolve the issue.