### PR TITLE
Dockerfile build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,14 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
         mbrola \
         mbrola-fr1 \
         python3 \
-        python3-pip \
-        python3-pytest && \
+        python3-pip && \
     apt-get clean
+
+# Pytest needs to be installed through pip to make sure we have a recent version
+RUN pip3 install pytest pytest-cov
+
+# Tests expect python to be available as executable 'python' not 'python3'
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # install phonemizer and run the tests
 RUN git clone https://github.com/bootphon/phonemizer.git && \


### PR DESCRIPTION
When I cloned the repository and ran `docker build -t phonemizer .` I received the following error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3/dist-packages/pytest.py", line 13, in <module>
    from _pytest.fixtures import fixture, yield_fixture
  File "/usr/lib/python3/dist-packages/_pytest/fixtures.py", line 842, in <module>
    class FixtureFunctionMarker(object):
  File "/usr/lib/python3/dist-packages/_pytest/fixtures.py", line 844, in FixtureFunctionMarker
    params = attr.ib(convert=attr.converters.optional(tuple))
TypeError: attrib() got an unexpected keyword argument 'convert'
```

This was caused by an outdated version of pytest that comes with installing `python3-pytest` through apt. I fixed this by installing `pytest` through pip. After that I had four failing tests:

```
=========================== short test summary info ============================
FAILED test/test_espeak.py::test_path_bad - Failed: DID NOT RAISE <class 'Run...
FAILED test/test_espeak.py::test_path_venv - TypeError: str expected, not Non...
FAILED test/test_festival.py::test_path_bad - Failed: DID NOT RAISE <class 'R...
FAILED test/test_festival.py::test_path_venv - TypeError: str expected, not N...
======================== 4 failed, 145 passed in 41.45s ========================
```

These were caused by the tests looking for `python` executable but only `python3` is available when installing python via apt. I modified the Dockerfile to create a symlink to the `python` executable rather than modifying the tests themselves.

You should be able to confirm that `docker build -t phonemizer .` works with the modified Dockerfile. Let me know if there is a different way you would like me to fix either of these issues! 