### PR TITLE
Update logger.py

### DIFF
--- a/phonemizer/logger.py
+++ b/phonemizer/logger.py
@@ -18,7 +18,7 @@ import logging
 import sys
 
 
-def get_logger(verbosity='normal'):
+def get_logger(verbosity='quiet'):
     """Returns a configured logging.Logger instance
 
     The logger is configured to output messages on the standard error stream
@@ -41,8 +41,8 @@ def get_logger(verbosity='normal'):
         raise RuntimeError(
             f'verbosity is {verbosity} but must be in '
             f'{", ".join(valid_verbosity)}')
-
-    logger = logging.getLogger()
+    
+    logger = logging.getLogger('phonemizer')
 
     # setup output to stderr
     logger.handlers = []


### PR DESCRIPTION
`import phonemizer` causes a call to `get_logger()` which configures the default logger. This causes duplicated logs if the same logger is used in the project importing Phonemizer. To avoid it, we have to call `get_logger('quiet')` after importing. It might be easier to name the logger used in Phonemizer (and to set it quiet by default).