### PR TITLE
Adding preserve_empty_lines option

### DIFF
--- a/phonemizer/__init__.py
+++ b/phonemizer/__init__.py
@@ -15,7 +15,7 @@
 """Multilingual text to phones converter"""
 
 
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 """Phonemizer version"""
 
 

--- a/phonemizer/backend/espeak/espeak.py
+++ b/phonemizer/backend/espeak/espeak.py
@@ -17,7 +17,7 @@
 import itertools
 import re
 from logging import Logger
-from typing import Optional, TYPE_CHECKING, Tuple, List, Union
+from typing import Optional, Tuple, List, Union
 
 from phonemizer.backend.espeak.base import BaseEspeakBackend
 from phonemizer.backend.espeak.language_switch import (
@@ -38,7 +38,7 @@ class EspeakBackend(BaseEspeakBackend):
                  punctuation_marks: Optional[str] = None,
                  preserve_punctuation: bool = False,
                  with_stress: bool = False,
-                 tie: bool = False,
+                 tie: Union[bool, str] = False,
                  language_switch: LanguageSwitch = 'keep-flags',
                  words_mismatch: WordMismatch = 'ignore',
                  logger: Optional[Logger] = None):

--- a/phonemizer/main.py
+++ b/phonemizer/main.py
@@ -173,6 +173,12 @@ Exemples:
         selecting the first one that is not configured as a token separator
         (see -p/-s/-w options).''')
 
+    group.add_argument(
+        '--preserve-empty-lines',
+        action='store_true',
+        help='''preserve the empty lines in the phonemized output, default is
+        to remove them.''')
+
     group = parser.add_argument_group('backends')
     group.add_argument(
         '-b', '--backend',
@@ -390,6 +396,7 @@ def main():
         separator=sep,
         strip=args.strip,
         prepend_text=args.prepend_text,
+        preserve_empty_lines=args.preserve_empty_lines,
         preserve_punctuation=args.preserve_punctuation,
         punctuation_marks=args.punctuation_marks,
         with_stress=args.with_stress,

--- a/phonemizer/phonemize.py
+++ b/phonemizer/phonemize.py
@@ -267,9 +267,12 @@ def _phonemize(  # pylint: disable=too-many-arguments
     # ignore empty lines
     text = [line for line in text if line.strip()]
 
-    # phonemize the text
-    phonemized = backend.phonemize(
-        text, separator=separator, strip=strip, njobs=njobs)
+    if(text):
+        # phonemize the text
+        phonemized = backend.phonemize(
+            text, separator=separator, strip=strip, njobs=njobs)
+    else:
+        phonemized = []
 
     # if preserving empty lines, reinsert them into text and phonemized lists
     if preserve_empty_lines:

--- a/phonemizer/phonemize.py
+++ b/phonemizer/phonemize.py
@@ -23,9 +23,12 @@ To use it in your own code, type:
 import os
 import sys
 from logging import Logger
-from typing import Optional
+from typing import Optional, Union, List
+
+from typing_extensions import Literal
 
 from phonemizer.backend import BACKENDS
+from phonemizer.backend.base import BaseBackend
 from phonemizer.backend.espeak.language_switch import LanguageSwitch
 from phonemizer.backend.espeak.words_mismatch import WordMismatch
 from phonemizer.logger import get_logger
@@ -33,19 +36,21 @@ from phonemizer.punctuation import Punctuation
 from phonemizer.separator import default_separator, Separator
 from phonemizer.utils import list2str, str2list
 
+Backend = Literal['espeak', 'espeak-mbrola', 'festival', 'segments']
+
 
 def phonemize(  # pylint: disable=too-many-arguments
         text,
         language: str = 'en-us',
-        backend: str = 'espeak',
+        backend: Backend = 'espeak',
         separator: Optional[Separator] = default_separator,
         strip: bool = False,
         prepend_text: bool = False,
         preserve_empty_lines: bool = False,
         preserve_punctuation: bool = False,
         punctuation_marks: str = Punctuation.default_marks(),
-        with_stress: str = False,
-        tie: str = False,
+        with_stress: bool = False,
+        tie: Union[bool, str] = False,
         language_switch: LanguageSwitch = 'keep-flags',
         words_mismatch: WordMismatch = 'ignore',
         njobs: int = 1,
@@ -205,7 +210,12 @@ def phonemize(  # pylint: disable=too-many-arguments
 
 
 def _check_arguments(  # pylint: disable=too-many-arguments
-        backend, with_stress, tie, separator, language_switch, words_mismatch):
+        backend: Backend,
+        with_stress: bool,
+        tie: Union[bool, str],
+        separator: Separator,
+        language_switch: LanguageSwitch,
+        words_mismatch: WordMismatch):
     """Auxiliary function to phonemize()
 
     Ensures the parameters are compatible with each other, raises a
@@ -251,7 +261,13 @@ def _check_arguments(  # pylint: disable=too-many-arguments
 
 
 def _phonemize(  # pylint: disable=too-many-arguments
-        backend, text, separator, strip, njobs, prepend_text, preserve_empty_lines):
+        backend: BaseBackend,
+        text: Union[str, List[str]],
+        separator: Separator,
+        strip: bool,
+        njobs: int,
+        prepend_text: bool,
+        preserve_empty_lines: bool):
     """Auxiliary function to phonemize()
 
     Does the phonemization and returns the phonemized text. Raises a
@@ -280,7 +296,7 @@ def _phonemize(  # pylint: disable=too-many-arguments
 
     # if preserving empty lines, reinsert them into text and phonemized lists
     if preserve_empty_lines:
-        for i in empty_lines:
+        for i in empty_lines: # noqa
             if prepend_text:
                 text.insert(i, '')
             phonemized.insert(i, '')

--- a/test/test_phonemize.py
+++ b/test/test_phonemize.py
@@ -188,44 +188,102 @@ def test_segments(njobs):
 
 
 @pytest.mark.parametrize(
-    'backend, empty_lines, punctuation, text, expected', [
-        ('espeak', False, False,
+    'backend, empty_lines, punctuation, prepend_text, text, expected', [
+        ('espeak', False, False, False,
             ['hello world!', '', 'goodbye'],
             ['həloʊ wɜːld ', 'ɡʊdbaɪ ']),
-        ('espeak', False, True,
+        ('espeak', False, True, False,
             ['hello world!', '', 'goodbye'],
             ['həloʊ wɜːld!', 'ɡʊdbaɪ ']),
-        ('espeak', True, False,
+        ('espeak', True, False, False,
             ['hello world!', '', 'goodbye'],
             ['həloʊ wɜːld ', '', 'ɡʊdbaɪ ']),
-        ('espeak', True, True,
+        ('espeak', True, True, False,
             ['hello world!', '', 'goodbye'],
             ['həloʊ wɜːld!', '', 'ɡʊdbaɪ ']),
-        ('segments', False, False,
+        ('segments', False, False, False,
             ['achi acho?', '', 'achi acho'],
             [u'ʌtʃɪ ʌtʃʊ ', u'ʌtʃɪ ʌtʃʊ ']),
-        ('segments', False, True,
+        ('segments', False, True, False,
             ['achi acho?', '', 'achi acho'],
             [u'ʌtʃɪ ʌtʃʊ?', u'ʌtʃɪ ʌtʃʊ ']),
-        ('segments', True, False,
+        ('segments', True, False, False,
             ['achi acho?', '', 'achi acho'],
             [u'ʌtʃɪ ʌtʃʊ ', '', u'ʌtʃɪ ʌtʃʊ ']),
-        ('segments', True, True,
+        ('segments', True, True, False,
             ['achi acho?', '', 'achi acho'],
             [u'ʌtʃɪ ʌtʃʊ?', '', u'ʌtʃɪ ʌtʃʊ ']),
-        ('festival', False, False,
+        ('festival', False, False, False,
             ['hello world!', '', 'goodbye'],
             ['hhaxlow werld ', 'guhdbay ']),
-        ('festival', False, True,
+        ('festival', False, True, False,
             ['hello world!', '', 'goodbye'],
             ['hhaxlow werld!', 'guhdbay ']),
-        ('festival', True, False,
+        ('festival', True, False, False,
             ['hello world!', '', 'goodbye'],
             ['hhaxlow werld ', '', 'guhdbay ']),
-        ('festival', True, True,
+        ('festival', True, True, False,
             ['hello world!', '', 'goodbye'],
-            ['hhaxlow werld!', '', 'guhdbay '])])
-def test_preserve_empty_lines(backend, empty_lines, punctuation, text, expected):
+            ['hhaxlow werld!', '', 'guhdbay ']),
+        ('espeak', False, False, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'həloʊ wɜːld '), ('goodbye', 'ɡʊdbaɪ ')]),
+        ('espeak', False, True, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'həloʊ wɜːld!'), ('goodbye', 'ɡʊdbaɪ ')]),
+        ('espeak', True, False, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'həloʊ wɜːld '), ('', ''), ('goodbye', 'ɡʊdbaɪ ')]),
+        ('espeak', True, True, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'həloʊ wɜːld!'), ('', ''), ('goodbye', 'ɡʊdbaɪ ')]),
+        ('segments', False, False, True,
+            ['achi acho?', '', 'achi acho'],
+            [('achi acho?', 'ʌtʃɪ ʌtʃʊ '), ('achi acho', u'ʌtʃɪ ʌtʃʊ ')]),
+        ('segments', False, True, True,
+            ['achi acho?', '', 'achi acho'],
+            [('achi acho?', 'ʌtʃɪ ʌtʃʊ?'), ('achi acho', u'ʌtʃɪ ʌtʃʊ ')]),
+        ('segments', True, False, True,
+            ['achi acho?', '', 'achi acho'],
+            [('achi acho?', u'ʌtʃɪ ʌtʃʊ '), ('', ''), ('achi acho', u'ʌtʃɪ ʌtʃʊ ')]),
+        ('segments', True, True, True,
+            ['achi acho?', '', 'achi acho'],
+            [('achi acho?', u'ʌtʃɪ ʌtʃʊ?'), ('', ''), ('achi acho', u'ʌtʃɪ ʌtʃʊ ')]),
+        ('festival', False, False, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'hhaxlow werld '), ('goodbye', 'guhdbay ')]),
+        ('festival', False, True, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'hhaxlow werld!'), ('goodbye', 'guhdbay ')]),
+        ('festival', True, False, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'hhaxlow werld '), ('', ''), ('goodbye', 'guhdbay ')]),
+        ('festival', True, True, True,
+            ['hello world!', '', 'goodbye'],
+            [('hello world!', 'hhaxlow werld!'), ('', ''), ('goodbye', 'guhdbay ')])])
+def test_preserve_empty_lines(backend, empty_lines, punctuation, prepend_text, text, expected):
+    language = 'cree' if backend == 'segments' else 'en-us'
+
+    assert expected == phonemize(
+        text, language=language, backend=backend, prepend_text=prepend_text,
+        preserve_punctuation=punctuation, preserve_empty_lines=empty_lines)
+
+
+@pytest.mark.parametrize(
+    'backend, empty_lines, punctuation, text, expected', [
+        ('espeak', False, False, [''], []),
+        ('espeak', False, True, [''], []),
+        ('espeak', True, False, [''], ['']),
+        ('espeak', True, True, [''], ['']),
+        ('segments', False, False, [''], []),
+        ('segments', False, True, [''], []),
+        ('segments', True, False, [''], ['']),
+        ('segments', True, True, [''], ['']),
+        ('festival', False, False, [''], []),
+        ('festival', False, True, [''], []),
+        ('festival', True, False, [''], ['']),
+        ('festival', True, True, [''], [''])])
+def test_empty_input(backend, empty_lines, punctuation, text, expected):
     language = 'cree' if backend == 'segments' else 'en-us'
 
     assert expected == phonemize(

--- a/test/test_phonemize.py
+++ b/test/test_phonemize.py
@@ -185,3 +185,49 @@ def test_segments(njobs):
         strip=True, njobs=njobs)
     assert out == os.linesep.join(
         ['untṵːlḛ ka̰ːpʼḛːl', 'o̰ːʃpʼḛːl', 'kantṵːlo̰ːn t̠͡ʃint̠͡ʃo'])
+
+
+@pytest.mark.parametrize(
+    'backend, empty_lines, punctuation, text, expected', [
+        ('espeak', False, False,
+            ['hello world!', '', 'goodbye'],
+            ['həloʊ wɜːld ', 'ɡʊdbaɪ ']),
+        ('espeak', False, True,
+            ['hello world!', '', 'goodbye'],
+            ['həloʊ wɜːld!', 'ɡʊdbaɪ ']),
+        ('espeak', True, False,
+            ['hello world!', '', 'goodbye'],
+            ['həloʊ wɜːld ', '', 'ɡʊdbaɪ ']),
+        ('espeak', True, True,
+            ['hello world!', '', 'goodbye'],
+            ['həloʊ wɜːld!', '', 'ɡʊdbaɪ ']),
+        ('segments', False, False,
+            ['achi acho?', '', 'achi acho'],
+            [u'ʌtʃɪ ʌtʃʊ ', u'ʌtʃɪ ʌtʃʊ ']),
+        ('segments', False, True,
+            ['achi acho?', '', 'achi acho'],
+            [u'ʌtʃɪ ʌtʃʊ?', u'ʌtʃɪ ʌtʃʊ ']),
+        ('segments', True, False,
+            ['achi acho?', '', 'achi acho'],
+            [u'ʌtʃɪ ʌtʃʊ ', '', u'ʌtʃɪ ʌtʃʊ ']),
+        ('segments', True, True,
+            ['achi acho?', '', 'achi acho'],
+            [u'ʌtʃɪ ʌtʃʊ?', '', u'ʌtʃɪ ʌtʃʊ ']),
+        ('festival', False, False,
+            ['hello world!', '', 'goodbye'],
+            ['hhaxlow werld ', 'guhdbay ']),
+        ('festival', False, True,
+            ['hello world!', '', 'goodbye'],
+            ['hhaxlow werld!', 'guhdbay ']),
+        ('festival', True, False,
+            ['hello world!', '', 'goodbye'],
+            ['hhaxlow werld ', '', 'guhdbay ']),
+        ('festival', True, True,
+            ['hello world!', '', 'goodbye'],
+            ['hhaxlow werld!', '', 'guhdbay '])])
+def test_preserve_empty_lines(backend, empty_lines, punctuation, text, expected):
+    language = 'cree' if backend == 'segments' else 'en-us'
+
+    assert expected == phonemize(
+        text, language=language, backend=backend,
+        preserve_punctuation=punctuation, preserve_empty_lines=empty_lines)


### PR DESCRIPTION
Adding the feature I requested in #95. 

Not stripping out the empty lines was causing problems with the festival backend and preserve_punctuation, so I took the approach of stripping out the empty lines pre-phonemization and then reinserting them afterward.

I want to flag that I changed the conversion of the input text to a list from a generator to list comprehension [here](https://github.com/jncasey/phonemizer/blob/a8a33d7557550ef63912e38b010c3fb6900f1dcc/phonemizer/phonemize.py#L261) since I needed to run through the list a second time to preserve the empty lines, and I thought this made the code easier to read than making another generator. I'm assuming that this won't make a big difference on performance given how I think phonemizer is generally used.