### PR TITLE
s/exemple/example/g

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -86,7 +86,7 @@ Install **espeak-ng** with the `.msi` Windows installer provided with
         EspeakWrapper.set_library('C:\Program Files\eSpeak NG\libespeak-ng.dll')
 
     An alternative is to define the environment variable
-    ``PHONEMIZER_ESPEAK_LIBRARY`` to the absolute path to the DLL. For exemple
+    ``PHONEMIZER_ESPEAK_LIBRARY`` to the absolute path to the DLL. For example
     if using conda have a:
 
     .. code-block:: bash

--- a/docs/source/python_examples.rst
+++ b/docs/source/python_examples.rst
@@ -11,7 +11,7 @@ See :py:meth:`phonemizer.phonemize`.
 Example 1: phonemize a text with festival
 -----------------------------------------
 
-The following exemple downloads a text and phonemizes it using the
+The following example downloads a text and phonemizes it using the
 festival backend, preserving punctuation and using 4 jobs in parallel.
 The phones are not separated, words are separated by a space and
 syllables by ``|``.
@@ -45,10 +45,10 @@ syllables by ``|``.
 Example 2: build a lexicon with espeak
 --------------------------------------
 
-The following exemple extracts a list of words present in a text,
+The following example extracts a list of words present in a text,
 ignoring punctuation, and builds a dictionary ``word: [phones]``,
 e.g. ``{'students': 's t uː d ə n t s', 'cobb': 'k ɑː b', 'its': 'ɪ t s', 'put': 'p ʊ t', ...}``.
-We consider here the same text as in the previous exemple.
+We consider here the same text as in the previous example.
 
 .. code:: python
 

--- a/phonemizer/main.py
+++ b/phonemizer/main.py
@@ -104,7 +104,7 @@ supported by each backend.
 
 ''',
         epilog='''
-Exemples:
+Examples:
 
 * Phonemize a US English text with espeak
 

--- a/phonemizer/phonemize.py
+++ b/phonemizer/phonemize.py
@@ -67,7 +67,7 @@ def phonemize(  # pylint: disable=too-many-arguments
     function: provide the input text as a list and call phonemize() a single
     time is much more efficient than calling it on each element of the list.
     Indeed the initialization of the phonemization backend can be expensive,
-    especially for espeak. In one exemple,
+    especially for espeak. In one example,
 
     Do this:
 


### PR DESCRIPTION
Replace occurences of "exemple" with "example" in English text in the code base.