### PR TITLE
Update japanese.g2p

### DIFF
--- a/phonemizer/share/segments/japanese.g2p
+++ b/phonemizer/share/segments/japanese.g2p
@@ -26,6 +26,7 @@ py	pʲ
 r	r
 ry	rʲ
 sh	ʃ
+s	s
 t	t
 ts	t͡s
 u	ɯ


### PR DESCRIPTION
The letter "s" was not included in this segments file, leading to many valid Japanese words being rejected:

```
> echo 'sushi' | phonemize -b segments -l japanese
fatal error: invalid grapheme
```