### PR TITLE
Make the segments backend an optional dependency

### DIFF
--- a/phonemizer/backend/__init__.py
+++ b/phonemizer/backend/__init__.py
@@ -19,9 +19,85 @@
 from .espeak.espeak import EspeakBackend
 from .espeak.mbrola import EspeakMbrolaBackend
 from .festival.festival import FestivalBackend
-from .segments import SegmentsBackend
+
+# The segments backend is imported lazily: it depends on the 'segments'
+# package, which in turn pulls in a heavy dependency chain (csvw, rdflib,
+# jsonschema, babel, language-tags). Users of the espeak or festival
+# backends do not need any of it. The import below therefore happens on
+# first access rather than at module import time, so that phonemizer
+# remains usable when 'segments' is not installed.
+
+__all__ = [
+    'EspeakBackend', 'EspeakMbrolaBackend', 'FestivalBackend',
+    'SegmentsBackend', 'BACKENDS']
 
 
-BACKENDS = {b.name(): b for b in (
-    EspeakBackend, FestivalBackend, SegmentsBackend, EspeakMbrolaBackend)}
+def _import_segments_backend():
+    """Import and return SegmentsBackend, raising a helpful error if missing"""
+    try:
+        from .segments import SegmentsBackend
+    except ImportError as err:  # pragma: nocover
+        raise ImportError(
+            'the segments backend requires the "segments" package, which '
+            'is not installed. Install it with "pip install segments" or '
+            '"pip install phonemizer[segments]".') from err
+    return SegmentsBackend
+
+
+def __getattr__(name):
+    """Lazy access to SegmentsBackend (PEP 562)
+
+    Allows "from phonemizer.backend import SegmentsBackend" to keep working
+    without importing the segments package when it is not needed.
+
+    """
+    if name == 'SegmentsBackend':
+        return _import_segments_backend()
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
+
+
+class _Backends(dict):
+    """A mapping of backend names to classes, resolving 'segments' lazily
+
+    Behaves as a regular dict for the espeak and festival backends. The
+    'segments' entry is only imported when it is actually looked up, so
+    that BACKENDS['espeak'] does not require the segments package.
+
+    """
+    _LAZY = {'segments': _import_segments_backend}
+
+    def __missing__(self, key):
+        if key in self._LAZY:
+            value = self._LAZY[key]()
+            self[key] = value
+            return value
+        raise KeyError(key)
+
+    def _all_keys(self):
+        keys = list(dict.__iter__(self))
+        keys.extend(k for k in self._LAZY if not dict.__contains__(self, k))
+        return keys
+
+    def __iter__(self):
+        return iter(self._all_keys())
+
+    def keys(self):
+        return self._all_keys()
+
+    def values(self):
+        return [self[k] for k in self._all_keys()]
+
+    def items(self):
+        return [(k, self[k]) for k in self._all_keys()]
+
+    def __contains__(self, key):
+        return dict.__contains__(self, key) or key in self._LAZY
+
+    def __len__(self):
+        return len(self._all_keys())
+
+
+BACKENDS = _Backends(
+    {b.name(): b for b in (
+        EspeakBackend, FestivalBackend, EspeakMbrolaBackend)})
 """The different phonemization backends as a mapping (name, class)"""

--- a/phonemizer/version.py
+++ b/phonemizer/version.py
@@ -14,10 +14,10 @@
 # along with phonemizer. If not, see <http://www.gnu.org/licenses/>.
 """Phonemizer version description"""
 
-import importlib
+import importlib.metadata
 
 from phonemizer.backend import (
-    EspeakBackend, EspeakMbrolaBackend, FestivalBackend, SegmentsBackend)
+    EspeakBackend, EspeakMbrolaBackend, FestivalBackend)
 
 
 def _version_as_str(vers):
@@ -52,7 +52,14 @@ def version():
     else:  # pragma: nocover
         unavailable.append('festival')
 
-    if SegmentsBackend.is_available():
+    # the segments backend is optional, it may not be installed at all
+    try:
+        from phonemizer.backend import SegmentsBackend
+        segments_available = SegmentsBackend.is_available()
+    except ImportError:  # pragma: nocover
+        segments_available = False
+
+    if segments_available:
         available.append(
             'segments-' + _version_as_str(SegmentsBackend.version()))
     else:  # pragma: nocover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,16 @@ requires-python = ">= 3.8"
 dynamic = ["version"]
 dependencies = [
     "joblib",
-    "segments",
     "attrs>=18.1",
     "dlinfo",
     "typing-extensions"]
 
 [project.optional-dependencies]
-test = ["pytest>=6.0", "pytest-cov", "coverage[toml]"]
+# the segments backend is optional: it pulls in a heavy dependency chain
+# (csvw, rdflib, jsonschema, babel, language-tags) that users of the espeak
+# and festival backends do not need. Install with "pip install phonemizer[segments]"
+segments = ["segments"]
+test = ["pytest>=6.0", "pytest-cov", "coverage[toml]", "segments"]
 doc = ["sphinx", "sphinx_rtd_theme"]
 
 [project.scripts]


### PR DESCRIPTION
Make the segments backend an optional dependency

## Problem

Installing phonemizer pulls in the `segments` package unconditionally,
which brings a large transitive dependency chain: `csvw`, `rdflib`,
`jsonschema`, `babel`, `language-tags`, `referencing`, `rpds-py`,
`uritemplate` and others.

Users of the espeak or festival backends never touch any of it. The only
reason it is installed is the eager import at the top of
`phonemizer/backend/__init__.py`:

```python
from .segments import SegmentsBackend
```

Measured in a clean virtualenv on Python 3.12:

| | packages installed |
|---|---|
| `pip install phonemizer` (current) | 15 |
| `pip install phonemizer` (this PR) | 5 |
| `pip install phonemizer[segments]` (this PR) | 15 |

This matters for anyone shipping phonemizer inside a constrained
environment. My own use case is a screen reader add-on, where `rdflib`
alone is a significant fraction of the bundle for a feature that is
never used.

## Change

`segments` moves to an optional dependency, and `SegmentsBackend` is
imported on first access instead of at import time.

Backwards compatibility is preserved throughout:

- `from phonemizer.backend import SegmentsBackend` keeps working, via a
  module level `__getattr__` (PEP 562)
- `BACKENDS` still reports all four backends in `keys()`, `values()`,
  `items()`, `__contains__` and `__len__`
- `BACKENDS['segments']` resolves the class on lookup, so code indexing
  the mapping is unaffected
- `BACKENDS['espeak']` no longer triggers the segments import
- when the package is absent, the `ImportError` explains how to install it

`version()` reports segments as an uninstalled backend when absent, in
line with how the other optional backends are already handled.

One incidental fix: `version.py` imported `importlib` but used
`importlib.metadata`. This worked only because the segments dependency
chain imported the submodule as a side effect. Without segments it raises
`AttributeError`, so the import is now explicit.

## Testing

Full test suite, same virtualenv, before and after:

```
baseline (unmodified master):  18 failed, 86 passed, 46 skipped
with this patch:               18 failed, 86 passed, 46 skipped
```

The same 18 tests fail in both runs. They are environment failures on
Windows (festival not installed, Arabic voice unavailable), not
regressions. `test_festival.py`, `test_main.py` and `test_punctuation.py`
were excluded because they fail at collection time without festival.

Additionally verified in a clean virtualenv with `segments` genuinely
absent (not stubbed) that the espeak backend produces output identical to
the `espeak-ng` command line, across 20 sentences in 8 languages (en, nl,
de, fr, es, it, pl, ru): 20/20 identical.

## Trade-off

Existing users who rely on the segments backend and upgrade without
changing their install command will get an `ImportError` on first use.
The error message names the fix. If you would prefer to avoid that
entirely, an alternative is to keep `segments` in `dependencies` for now
and only make the import lazy, which still avoids loading rdflib at
runtime but keeps the install size unchanged. Happy to reshape the PR
either way.
