### PR TITLE
Cache backend instances in phonemize()

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,12 @@ Version numbers follow `semantic versioning <https://semver.org>`__.
 not yet released
 -----------------
 
+* **improvements**
+
+  * ``phonemize()`` now reuses backend instances across calls instead of
+    building a new one every time. See `PR #212
+    <https://github.com/bootphon/phonemizer/pull/212>`__.
+
 * **bug fixes**
 
   * Tests related to `festival` backend are now skipped when `festival` is not installed on the system.

--- a/phonemizer/phonemize.py
+++ b/phonemizer/phonemize.py
@@ -22,6 +22,7 @@ To use it in your own code, type:
 
 import os
 import sys
+from collections import OrderedDict
 from logging import Logger
 from typing import Optional, Union, List, Pattern
 
@@ -37,6 +38,39 @@ from phonemizer.separator import default_separator, Separator
 from phonemizer.utils import list2str, str2list
 
 Backend = Literal['espeak', 'espeak-mbrola', 'festival', 'segments']
+
+# Backend instances are expensive to build: initializing the espeak shared
+# library takes on the order of 200ms, which dominates the cost of
+# phonemizing short texts. Because phonemize() builds a backend on every
+# call, repeated calls pay that cost every time. The instances are stateless
+# with respect to the text being phonemized, so they are cached here and
+# reused across calls with identical parameters.
+_BACKENDS_CACHE: 'OrderedDict[tuple, BaseBackend]' = OrderedDict()
+
+_CACHE_MAX_SIZE = 8
+"""Maximum number of backend instances kept alive simultaneously"""
+
+
+def _cached_backend(key, factory):
+    """Return a backend for `key`, building it with `factory` if needed"""
+    try:
+        backend = _BACKENDS_CACHE.pop(key)
+    except KeyError:
+        backend = factory()
+        if len(_BACKENDS_CACHE) >= _CACHE_MAX_SIZE:
+            _BACKENDS_CACHE.popitem(last=False)
+    _BACKENDS_CACHE[key] = backend
+    return backend
+
+
+def clear_backends_cache():
+    """Free the backend instances cached by phonemize()
+
+    Called for its side effect only. The cache is repopulated on the next
+    call to phonemize().
+
+    """
+    _BACKENDS_CACHE.clear()
 
 
 def phonemize(  # pylint: disable=too-many-arguments
@@ -201,9 +235,13 @@ def phonemize(  # pylint: disable=too-many-arguments
     if backend == 'espeak-mbrola' and separator.word:
         logger.warning('espeak-mbrola backend cannot preserve word separation')
 
-    # initialize the phonemization backend
+    # initialize the phonemization backend, reusing a cached instance when
+    # this exact configuration has been used before. The logger is part of
+    # the key because backends hold on to it.
     if backend == 'espeak':
-        phonemizer = BACKENDS[backend](
+        key = (backend, language, str(punctuation_marks), preserve_punctuation,
+               with_stress, tie, language_switch, words_mismatch, logger)
+        phonemizer = _cached_backend(key, lambda: BACKENDS[backend](
             language,
             punctuation_marks=punctuation_marks,
             preserve_punctuation=preserve_punctuation,
@@ -211,17 +249,20 @@ def phonemize(  # pylint: disable=too-many-arguments
             tie=tie,
             language_switch=language_switch,
             words_mismatch=words_mismatch,
-            logger=logger)
+            logger=logger))
     elif backend == 'espeak-mbrola':
-        phonemizer = BACKENDS[backend](
+        key = (backend, language, logger)
+        phonemizer = _cached_backend(key, lambda: BACKENDS[backend](
             language,
-            logger=logger)
+            logger=logger))
     else:  # festival or segments
-        phonemizer = BACKENDS[backend](
+        key = (backend, language, str(punctuation_marks), preserve_punctuation,
+               logger)
+        phonemizer = _cached_backend(key, lambda: BACKENDS[backend](
             language,
             punctuation_marks=punctuation_marks,
             preserve_punctuation=preserve_punctuation,
-            logger=logger)
+            logger=logger))
 
     # do the phonemization
     return _phonemize(phonemizer, text, separator, strip, njobs, prepend_text, preserve_empty_lines)


### PR DESCRIPTION
Cache backend instances in phonemize()

## Problem

`phonemize()` constructs a backend on every call and discards it when it
returns. Constructing an espeak backend initializes the espeak shared
library, which takes around 190ms. Any code that phonemizes many short
texts in a loop pays that cost on every single call.

Measured on Python 3.12 with espeak-ng 1.52, phonemizing single words:

```
per call, current master:  190 ms
```

The cost is invisible when phonemizing one large text, and dominant when
phonemizing many small ones. It is a common pattern in TTS front-ends,
where each utterance is phonemized separately as it arrives.

Worth noting: this makes the documented "phonemization is slow" workaround
in the FAQ (instantiate a backend yourself and call `backend.phonemize()`)
effectively mandatory for anyone in a loop. This PR makes the top level
function competitive with doing that by hand.

## Change

Backend instances are stateless with respect to the text being phonemized,
so they can be reused. They are now cached and looked up by their full
configuration.

```
first call:       190 ms
subsequent calls:   0.047 ms
```

Details:

- The cache key covers every constructor argument. The logger is included
  because backends keep a reference to it, so two callers with different
  loggers must not share an instance.
- The cache is bounded to 8 entries with least-recently-used eviction, so
  phonemizing a sequence of languages does not keep every backend alive
  indefinitely. Espeak backends hold a handle on the shared library, so an
  unbounded cache would be a real leak.
- `clear_backends_cache()` is exposed for callers that want to release the
  instances explicitly.

## Testing

Full test suite, same virtualenv, before and after:

```
baseline (unmodified master):  18 failed, 86 passed, 46 skipped in 22.85s
with this patch:               18 failed, 86 passed, 46 skipped in 15.27s
```

The same 18 tests fail in both runs. They are environment failures on
Windows (festival not installed, Arabic voice unavailable), not
regressions. `test_festival.py`, `test_main.py` and `test_punctuation.py`
were excluded because they fail at collection time without festival.

The suite is a third faster with the patch, which is the same effect the
change is meant to produce for library users.

Additional checks, beyond the existing suite:

- repeated calls return identical output, and identical to the `espeak-ng`
  command line
- calls that differ in any parameter (`with_stress`, language, ...) get
  distinct backends rather than a stale cache hit
- the cache stays bounded when phonemizing 12 different languages
- `clear_backends_cache()` empties it

## Trade-off

Backend instances now outlive the call, so an espeak backend keeps the
shared library loaded until it is evicted or the cache is cleared.
Previously each instance was released promptly. The bound of 8 caps the
exposure. If you would prefer a different bound, an opt-in flag, or no
eviction at all, I am happy to adjust.
