### PR TITLE
Add option to use a custom espeak data path

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,13 @@ Version numbers follow `semantic versioning <https://semver.org>`__.
 not yet released
 -----------------
 
+* **improvements**
+
+  * The espeak data directory can now be chosen with
+    ``EspeakWrapper.set_data_path()`` or the environment variable
+    ``PHONEMIZER_ESPEAK_DATA_PATH``. See `PR #213
+    <https://github.com/bootphon/phonemizer/pull/213>`__.
+
 * **bug fixes**
 
   * Tests related to `festival` backend are now skipped when `festival` is not installed on the system.

--- a/phonemizer/backend/espeak/api.py
+++ b/phonemizer/backend/espeak/api.py
@@ -40,10 +40,13 @@ class EspeakAPI:
 
     """
 
-    def __init__(self, library: Union[str, Path]):
+    def __init__(self, library: Union[str, Path], data_path: Union[str, Path, None]):
         # set to None to avoid an AttributeError in _delete if the __init__
         # method raises, will be properly initialized below
         self._library = None
+        
+        if data_path is not None:
+            data_path = str(data_path).encode('utf-8')
 
         # Because the library is not designed to be wrapped nor to be used in
         # multithreaded/multiprocess contexts (massive use of global variables)
@@ -83,7 +86,7 @@ class EspeakAPI:
         # AUDIO_OUTPUT_SYNCHRONOUS in the espeak API
         self._library = ctypes.cdll.LoadLibrary(str(espeak_copy))
         try:
-            if self._library.espeak_Initialize(0x02, 0, None, 0) <= 0:
+            if self._library.espeak_Initialize(0x02, 0, data_path, 0) <= 0:
                 raise RuntimeError(  # pragma: nocover
                     'failed to initialize espeak shared library')
         except AttributeError:  # pragma: nocover

--- a/phonemizer/backend/espeak/wrapper.py
+++ b/phonemizer/backend/espeak/wrapper.py
@@ -76,6 +76,7 @@ class EspeakWrapper:
     # on the system. The user can choose an alternative espeak library with
     # the method EspeakWrapper.set_library().
     _ESPEAK_LIBRARY = None
+    _ESPEAK_DATA_PATH = None
 
     def __init__(self):
         # the following attributes are accessed through properties and are
@@ -85,7 +86,7 @@ class EspeakWrapper:
         self._voice = None
 
         # load the espeak API
-        self._espeak = EspeakAPI(self.library())
+        self._espeak = EspeakAPI(self.library(), self.data_path)
 
         # lazy loading of attributes only required for the synthetize method
         self._libc_ = None
@@ -144,6 +145,21 @@ class EspeakWrapper:
 
         """
         cls._ESPEAK_LIBRARY = library
+        
+    @classmethod
+    def set_data_path(cls, data_path: str):
+        """Sets the path for the data to be used by the espeak backend.
+
+        If this is not set, the backend uses the default data path from the system installation.
+
+        Parameters
+        ----------
+        data_path : str
+            The path to the data to be used by the espeak backend. Set `data_path` to None
+            to restore the default.
+
+        """
+        cls._ESPEAK_DATA_PATH = data_path
 
     @classmethod
     def library(cls):
@@ -207,8 +223,37 @@ class EspeakWrapper:
 
     @property
     def data_path(self):
-        """The espeak data directory as a pathlib.Path instance"""
-        if self._data_path is None:
+        """Returns the espeak library used as backend
+
+        The following precedence rule applies for library lookup:
+
+        1. As specified by BaseEspeakBackend.set_library()
+        2. Or as specified by the environment variable
+           PHONEMIZER_ESPEAK_LIBRARY
+        3. Or the default espeak library found on the system
+
+        Raises
+        ------
+        RuntimeError if the espeak library cannot be found or if the
+          environment variable PHONEMIZER_ESPEAK_LIBRARY is set to a
+          non-readable file
+
+        """
+        if self._ESPEAK_DATA_PATH:
+            data_path = pathlib.Path(self._ESPEAK_DATA_PATH)
+            if not (data_path.is_dir() and os.access(self._ESPEAK_DATA_PATH, os.R_OK)):
+                raise RuntimeError(f'{self._ESPEAK_DATA_PATH} is not a readable directory')
+            self._data_path = data_path.resolve()
+        elif 'PHONEMIZER_ESPEAK_DATA_PATH' in os.environ:
+            data_path = pathlib.Path(os.environ['PHONEMIZER_ESPEAK_DATA_PATH'])
+            if not (data_path.is_dir() and os.access(data_path, os.R_OK)):
+                raise RuntimeError(  # pragma: nocover
+                    f'PHONEMIZER_ESPEAK_DATA_PATH={data_path} '
+                    f'is not a readable directory')
+            self._data_path = data_path.resolve()
+        
+        # Fetch path dynamically after initialize
+        if self._data_path is None and hasattr(self, '_espeak'):
             self._fetch_version_and_path()
         return self._data_path
 

--- a/phonemizer/backend/espeak/wrapper.py
+++ b/phonemizer/backend/espeak/wrapper.py
@@ -145,7 +145,7 @@ class EspeakWrapper:
 
         """
         cls._ESPEAK_LIBRARY = library
-        
+
     @classmethod
     def set_data_path(cls, data_path: str):
         """Sets the path for the data to be used by the espeak backend.
@@ -223,20 +223,18 @@ class EspeakWrapper:
 
     @property
     def data_path(self):
-        """Returns the espeak library used as backend
+        """The espeak data directory as a pathlib.Path instance
 
-        The following precedence rule applies for library lookup:
+        The following precedence rule applies for data path lookup:
 
-        1. As specified by BaseEspeakBackend.set_library()
+        1. As specified by EspeakWrapper.set_data_path()
         2. Or as specified by the environment variable
-           PHONEMIZER_ESPEAK_LIBRARY
-        3. Or the default espeak library found on the system
+           PHONEMIZER_ESPEAK_DATA_PATH
+        3. Or the data directory of the espeak library in use
 
         Raises
         ------
-        RuntimeError if the espeak library cannot be found or if the
-          environment variable PHONEMIZER_ESPEAK_LIBRARY is set to a
-          non-readable file
+        RuntimeError if the specified data path is not a readable directory
 
         """
         if self._ESPEAK_DATA_PATH:
@@ -251,7 +249,7 @@ class EspeakWrapper:
                     f'PHONEMIZER_ESPEAK_DATA_PATH={data_path} '
                     f'is not a readable directory')
             self._data_path = data_path.resolve()
-        
+
         # Fetch path dynamically after initialize
         if self._data_path is None and hasattr(self, '_espeak'):
             self._fetch_version_and_path()


### PR DESCRIPTION
Add option to use a custom espeak data path

## Credit

**The code in this PR is not mine.** It is a cherry-pick of
[`cc1db4b`](https://github.com/thewh1teagle/phonemizer-fork/commit/cc1db4b)
by [@thewh1teagle](https://github.com/thewh1teagle), from
[thewh1teagle/phonemizer-fork](https://github.com/thewh1teagle/phonemizer-fork).
The commit is applied with authorship preserved, so git history and the
GitHub UI both attribute it to him rather than to me.

I am opening this because the change is useful and, as far as I can tell,
was never proposed here. If @thewh1teagle would rather submit it himself,
or would rather it not be upstreamed at all, I will close this without
hesitation.

## What it does

`espeak_Initialize()` currently receives `None` as its data path argument,
which makes espeak fall back on its own lookup: environment variables,
standard install locations, and paths relative to the library. That is
fine when espeak-ng is installed system-wide.

It is not fine when phonemizer is embedded in a redistributable
application. In my case that is a screen reader add-on: the user should
not have to install espeak-ng separately, so the library and its data are
bundled with the application. Without control over the data path there is
no reliable way to point espeak at the bundled data.

This adds `EspeakWrapper.set_data_path()`, mirroring the existing
`set_library()`, plus a `PHONEMIZER_ESPEAK_DATA_PATH` environment
variable, mirroring `PHONEMIZER_ESPEAK_LIBRARY`. When neither is set the
behaviour is unchanged: `None` is passed and espeak looks up the data
itself.

## Testing

Full test suite, same virtualenv, before and after:

```
baseline (unmodified master):  18 failed, 86 passed, 46 skipped
with this patch:               18 failed, 86 passed, 46 skipped
```

The same 18 tests fail in both runs. They are environment failures on
Windows (festival not installed, Arabic voice unavailable), not
regressions. `test_festival.py`, `test_main.py` and `test_punctuation.py`
were excluded because they fail at collection time without festival.

Manual checks on Windows with espeak-ng 1.52:

- default behaviour unchanged, output identical to the `espeak-ng`
  command line
- with an explicit data path set, phonemes are identical to the default
- an unreadable or non-existent path raises a clear `RuntimeError`

## Note

There is no test coverage for the new code path in this PR, since the
cherry-picked commit did not add any and I did not want to alter someone
else's commit. Happy to add tests in a follow-up commit if you would like
this merged.
