### PR TITLE
fix: find the espeak-ng library on a stock Windows install

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,10 @@ not yet released
 
 * **bug fixes**
 
+  * The espeak library is now also looked up under its ``lib``-prefixed names,
+    so a stock espeak-ng installation on Windows is found. See `PR #214
+    <https://github.com/bootphon/phonemizer/pull/214>`__.
+
   * Tests related to `festival` backend are now skipped when `festival` is not installed on the system.
 
   * Improved espeak library lookup on macos.

--- a/phonemizer/backend/espeak/wrapper.py
+++ b/phonemizer/backend/espeak/wrapper.py
@@ -174,7 +174,17 @@ class EspeakWrapper:
                 )
             return library.resolve()
 
-        library = _find_library("espeak-ng") or _find_library("espeak")
+        library = (
+            _find_library("espeak-ng")
+            or _find_library("espeak")
+            # The official espeak-ng Windows installer ships the DLL as
+            # "libespeak-ng.dll". ctypes.util.find_library does not add a
+            # "lib" prefix on Windows (unlike Linux, where it resolves
+            # "espeak-ng" to "libespeak-ng.so"), so the two names above miss
+            # a perfectly normal installation that is already on PATH.
+            or _find_library("libespeak-ng")
+            or _find_library("libespeak")
+        )
         if not library:  # pragma: nocover
             raise RuntimeError("failed to find espeak library")
         return library

--- a/test/test_espeak_wrapper.py
+++ b/test/test_espeak_wrapper.py
@@ -138,3 +138,21 @@ def test_deletion():
     path = pathlib.Path(wrapper._espeak._tempdir)
     del wrapper
     assert not path.exists()
+
+
+@pytest.mark.skipif(
+    "PHONEMIZER_ESPEAK_LIBRARY" in os.environ,
+    reason="PHONEMIZER_ESPEAK_LIBRARY takes precedence over the lookup",
+)
+def test_library_found_without_configuration():
+    """The library must be found on a stock installation.
+
+    On Windows the official espeak-ng installer names the DLL
+    "libespeak-ng.dll". ctypes.util.find_library does not add a "lib" prefix
+    there (unlike Linux, where "espeak-ng" resolves to "libespeak-ng.so"), so
+    looking up only "espeak-ng"/"espeak" missed an installation that was
+    already on PATH.
+    """
+    library = EspeakWrapper.library()
+    assert library
+    assert pathlib.Path(str(library)).name.lower().startswith(("espeak", "libespeak"))


### PR DESCRIPTION
## The problem

`EspeakBackend.is_available()` returns `False` on Windows even when espeak-ng is installed and on `PATH`, so `phonemize()` fails until the caller sets `PHONEMIZER_ESPEAK_LIBRARY` or calls `EspeakWrapper.set_library()` by hand:

```python
>>> from phonemizer.backend import EspeakBackend
>>> EspeakBackend.is_available()
False
>>> EspeakBackend.version()
RuntimeError: failed to find espeak library
```

…with a completely ordinary installation:

```
C:\Program Files\eSpeak NG\libespeak-ng.dll   exists
C:\Program Files\eSpeak NG\espeak-ng.exe      exists, on PATH
```

## Why

`EspeakWrapper.library()` tries:

```python
ctypes.util.find_library('espeak-ng') or ctypes.util.find_library('espeak')
```

On Linux `find_library` adds the `lib` prefix and the `.so` suffix, so `'espeak-ng'` resolves to `libespeak-ng.so`. **On Windows it does not** — it looks for `espeak-ng.dll`, while the official installer ships the DLL as `libespeak-ng.dll`:

```python
>>> ctypes.util.find_library('espeak-ng')
None
>>> ctypes.util.find_library('libespeak-ng')
'C:\\Program Files\\eSpeak NG\\libespeak-ng.dll'
```

## The fix

Add the lib-prefixed names as further fallbacks, **after** the existing two, so nothing changes on platforms where those already resolve. Result:

```python
>>> EspeakBackend.is_available()
True
>>> EspeakBackend.version()
(1, 52, 0)
>>> phonemize('The file has been saved', language='en-us', backend='espeak', with_stress=True)
'ðə fˈaɪl hˈæzbiːn sˈeɪvd '
```

## Tests

`test/test_espeak_wrapper.py` gains a check that the library is found without any configuration. It is skipped when `PHONEMIZER_ESPEAK_LIBRARY` is set, matching the existing skip pattern in that file, since the environment variable takes precedence over the lookup.

## Test run notes

Tested on Windows 11, Python 3.12, espeak-ng 1.52 from the official installer.

The espeak-related suites give **51 passed, 2 failed**. Both failures are pre-existing on `master` (verified by stashing this change) and are unrelated to it:

- `test_espeak.py::test_arabic` — `failed to load voice "ar"`
- `test_espeak_wrapper.py::test_available_voices` — espeak and mbrola voice sets overlap

Both come from the same thing: on a stock Windows install the mbrola voice variants shadow the plain voices for `ar`, `cs`, `el`, `hi` and `ja`, and there is no way to reach the plain voice by name through the backend API. The test's own comment already anticipates the Windows/CI case here. Happy to look at that separately if it is of interest.

`test_festival.py`, `test_main.py` and `test_punctuation.py` fail to collect because festival is not available on Windows — also unrelated.
