### PR TITLE
fix: don't let mbrola variants shadow the plain voice of a language

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,11 @@ not yet released
 
 * **bug fixes**
 
+  * Selecting a language by its code no longer resolves to an mbrola variant
+    that shadows the plain espeak voice, which made such languages unusable
+    when the mbrola binary is absent. See `PR #215
+    <https://github.com/bootphon/phonemizer/pull/215>`__.
+
   * Tests related to `festival` backend are now skipped when `festival` is not installed on the system.
 
   * Improved espeak library lookup on macos.

--- a/phonemizer/backend/espeak/wrapper.py
+++ b/phonemizer/backend/espeak/wrapper.py
@@ -279,9 +279,20 @@ class EspeakWrapper:
         else:
             # this are espeak voices. Select the voice using it's attached
             # language code. Consider only the first voice of a given code as
-            # they are sorted by relevancy
+            # they are sorted by relevancy.
+            #
+            # Skip the mbrola variants here: they are listed under the same
+            # language code as the plain espeak voice and can sort first (on
+            # Windows "ar" lists mb/mb-ar1, mb/mb-ar2, sem/ar in that order),
+            # but they need the mbrola binary, which is not part of an espeak
+            # installation. Picking one when it is absent makes the language
+            # unusable even though a working voice exists further down the
+            # list. Mbrola voices remain reachable through the 'mb-*' codes
+            # handled above.
             available = {}
             for voice in self.available_voices():
+                if str(voice.identifier).replace("\\", "/").startswith("mb/"):
+                    continue
                 if voice.language not in available:
                     available[voice.language] = voice.identifier
 

--- a/test/test_espeak_wrapper.py
+++ b/test/test_espeak_wrapper.py
@@ -24,7 +24,7 @@ import sys
 
 import pytest
 
-from phonemizer.backend import EspeakMbrolaBackend
+from phonemizer.backend import EspeakBackend, EspeakMbrolaBackend
 from phonemizer.backend.espeak.wrapper import EspeakWrapper
 
 
@@ -150,6 +150,9 @@ def test_mbrola_does_not_shadow_plain_voice(wrapper, language):
     entry then picks a voice needing the mbrola binary, making the language
     unusable even though a working voice exists further down the list.
     """
+    if not EspeakBackend.is_supported_language(language):
+        pytest.skip(f"{language} is not supported by this espeak version")
+
     wrapper.set_voice(language)
     assert wrapper.voice is not None
 

--- a/test/test_espeak_wrapper.py
+++ b/test/test_espeak_wrapper.py
@@ -138,3 +138,21 @@ def test_deletion():
     path = pathlib.Path(wrapper._espeak._tempdir)
     del wrapper
     assert not path.exists()
+
+
+@pytest.mark.parametrize("language", ["ar", "cs", "el", "hi", "ja", "ms"])
+def test_mbrola_does_not_shadow_plain_voice(wrapper, language):
+    """A language with mbrola variants must still resolve to a usable voice.
+
+    These languages list their mbrola variants under the same language code as
+    the plain espeak voice, and the mbrola ones can sort first (on Windows "ar"
+    lists mb/mb-ar1, mb/mb-ar2, sem/ar in that order). Selecting the first
+    entry then picks a voice needing the mbrola binary, making the language
+    unusable even though a working voice exists further down the list.
+    """
+    wrapper.set_voice(language)
+    assert wrapper.voice is not None
+
+    identifier = str(wrapper.voice.identifier).replace(os.sep, "/")
+    assert not identifier.startswith("mb/")
+    assert wrapper.text_to_phonemes("test").strip()


### PR DESCRIPTION
## The problem

Six languages cannot be used through the espeak library backend, even though `espeak-ng` handles them fine from the command line:

```python
>>> EspeakBackend('ar')
RuntimeError: failed to load voice "ar"
```

```
$ espeak-ng -q -x --ipa -v ar   # works
mrħbˈaː
```

Affected: **ar, cs, el, hi, ja, ms**.

## Why

`set_voice()` builds its language → voice map by keeping the first voice of each language code, assuming the list is sorted by relevancy. For these six the mbrola variants share the language code with the plain espeak voice and sort ahead of it:

```
ar -> mb/mb-ar1, mb/mb-ar2, sem/ar
cs -> mb/mb-cz1, mb/mb-cz2, zlw/cs
el -> mb/mb-gr2, grk/el, mb/mb-gr1
hi -> mb/mb-in1, mb/mb-in2, inc/hi
ja -> mb/mb-jp1, mb/mb-jp2, mb/mb-jp3, jpx/ja
ms -> mb/mb-ma1, poz/ms
```

The mbrola entry wins, and loading it fails without the mbrola binary — which is a separate project whose last release (2019) ships source only, with no Windows build. So the language is unreachable even though a working voice is listed right below it.

There is no workaround through the public API: `EspeakBackend('sem/ar')` and every other identifier form are rejected, because the map is keyed by language code.

## The fix

Skip mbrola variants when building the map for a plain language code, so the first *usable* voice is selected. Mbrola voices are unaffected — `mb-*` codes take the separate branch above this one and still resolve as before.

## Result

On Windows this takes the library backend from **56/63 to 62/63** of the languages the espeak-ng binary supports — the same coverage as the binary itself.

Output for all six verified identical to `espeak-ng -q -x --ipa`:

| lang | output |
|---|---|
| ar | `mrħbˈaː` |
| cs | `dˈobriː dˈen` |
| el | `kˌalimˈera` |
| hi | `nəmˈʌsteː` |
| ja | `kˌo̞nnitɕˈihä` |
| ms | `səlˈamat pˈaɡi` |

## Tests

A parametrised test over the six languages asserting the resolved voice is not an mbrola one and that phonemization actually produces output.

This also fixes the pre-existing `test_espeak.py::test_arabic` failure on Windows.

## Test run notes

Tested on Windows 11, Python 3.12, espeak-ng 1.52 from the official installer.

`test_espeak_wrapper.py::test_available_voices` still fails, but it does so on `master` too (verified by stashing this change) and is unrelated — it asserts that the espeak and mbrola voice sets do not intersect, which is exactly the overlap described above. The test's own comment already flags Windows as a special case here. I left it alone since changing it is a separate judgement call about what the intended invariant is.

`test_festival.py`, `test_main.py` and `test_punctuation.py` fail to collect because festival is not installable on Windows — also unrelated.

## Relation to #214

Independent. #214 makes the library *findable* on Windows; this makes six languages *usable* once it is found. Neither depends on the other, and they touch different functions in the same file. Happy to rebase whichever lands second.
