### PR TITLE
fix: don't split a number on its decimal separator

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,13 @@ not yet released
 
 * **bug fixes**
 
+  * **Behaviour change:** a comma or period between two digits is no longer
+    treated as punctuation, so numbers such as ``19,99`` and ``3.14`` are kept
+    whole instead of being split into two numbers. Splitting them changed the
+    spoken output. The previous behaviour can still be obtained by passing an
+    explicit regex as ``punctuation_marks``. See `PR #216
+    <https://github.com/bootphon/phonemizer/pull/216>`__.
+
   * Tests related to `festival` backend are now skipped when `festival` is not installed on the system.
 
   * Improved espeak library lookup on macos.

--- a/phonemizer/punctuation.py
+++ b/phonemizer/punctuation.py
@@ -24,6 +24,10 @@ from phonemizer.separator import Separator
 # The punctuation marks considered by default.
 _DEFAULT_MARKS = ';:,.!?¡¿—…"«»“”(){}[]'
 
+# Marks that are also used as a decimal separator, and so must not be treated
+# as punctuation when they sit between two digits.
+_DECIMAL_SEPARATORS = ',.'
+
 _MarkIndex = collections.namedtuple(
     '_mark_index', ['index', 'mark', 'position'])
 
@@ -72,7 +76,30 @@ class Punctuation:
 
             # catching all the marks in one regular expression: zero or more spaces
             # + one or more marks + zero or more spaces.
-            self._marks_re = re.compile(fr'(\s*[{re.escape(self._marks)}]+\s*)+')
+            #
+            # A mark that doubles as a decimal separator is excluded when it sits
+            # between two digits, so that a decimal number reaches the backend
+            # intact. Splitting "1,5" into "1" and "5" makes espeak read two
+            # separate numbers ("one five" instead of "one comma five"), which
+            # changes the value being spoken -- "19,99 euro" became "nineteen
+            # ninety-nine euro". A separator adjacent to a non-digit, or at the
+            # end of a token, is ordinary punctuation and still split as before.
+            decimals = ''.join(
+                m for m in self._marks if m in _DECIMAL_SEPARATORS)
+            others = ''.join(
+                m for m in self._marks if m not in _DECIMAL_SEPARATORS)
+
+            alternatives = []
+            if others:
+                alternatives.append(f'[{re.escape(others)}]')
+            if decimals:
+                escaped = re.escape(decimals)
+                # not preceded by a digit, or not followed by one
+                alternatives.append(f'(?<![0-9])[{escaped}]')
+                alternatives.append(f'[{escaped}](?![0-9])')
+
+            self._marks_re = re.compile(
+                fr'(\s*(?:{"|".join(alternatives)})+\s*)+')
         else:
             raise ValueError('punctuation marks must be defined as a string or re.Pattern')
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -143,9 +143,9 @@ def test_festival_path():
 @pytest.mark.parametrize(
     'args, expected', [
         ('',
-         'həloʊ wɜːld θɹiː ziəɹoʊziəɹoʊ ziəɹoʊ ɔːɹ tuː fɪfti həloʊ '),
+         'həloʊ wɜːld θɹiː θaʊzənd ɔːɹ tuː pɔɪnt faɪv ziəɹoʊ həloʊ '),
         ('--preserve-punctuation',
-         'həloʊ, ,wɜːld? θɹiː,ziəɹoʊziəɹoʊ ziəɹoʊ, ɔːɹ tuː.fɪfti. ¿həloʊ? '),
+         'həloʊ, ,wɜːld? θɹiː θaʊzənd, ɔːɹ tuː pɔɪnt faɪv ziəɹoʊ. ¿həloʊ? '),
         ('--preserve-punctuation '
          '--punctuation-marks-is-regex '
          '--punctuation-marks "[^a-zA-ZÀ-ÖØ-öø-ÿ0-9\'\\-]"',

--- a/test/test_punctuation.py
+++ b/test/test_punctuation.py
@@ -277,3 +277,31 @@ def test_long_document():
 def test_multiline_punctuation(text):
     phonemized = phonemize(text, preserve_punctuation=True)
     assert len(text) == len(phonemized)
+
+
+# A mark that doubles as a decimal separator must not split a number: espeak
+# then reads two separate numbers and the spoken value changes ("19,99 euro"
+# became "nineteen ninety-nine euro"). A separator next to a non-digit is
+# ordinary punctuation and is still split.
+@pytest.mark.parametrize('text,expected', [
+    ('1,5', '1,5'),
+    ('3.14', '3.14'),
+    ('19,99 euro', '19,99 euro'),
+    ('version 2.5', 'version 2.5'),
+    # first comma is a decimal separator, second is punctuation
+    ('1,5, and more', '1,5 and more'),
+    # a separator at the end of a number is punctuation
+    ('I have 42.', 'I have 42'),
+    ('42, 43', '42 43'),
+    ('line 42, column 7', 'line 42 column 7'),
+])
+def test_decimal_separator_not_split(text, expected):
+    assert Punctuation().remove(text) == expected
+
+
+@pytest.mark.parametrize('text', ['1,5 and more', '19,99 euro', 'hello, world'])
+def test_decimal_separator_preserve_restore(text):
+    punctuation = Punctuation()
+    preserved, marks = punctuation.preserve([text])
+    restored = punctuation.restore(preserved, marks, default_separator, True)
+    assert restored == [text]

--- a/test/test_punctuation.py
+++ b/test/test_punctuation.py
@@ -222,7 +222,7 @@ def test_issue55(backend, marks, text, expected):
     'punctuation_marks, text, expected', [
         (';:,.!?¡—…"«»“”',
          'hello, ,world? ‡ 3,000, or 2.50. ¿hello?',
-         'həloʊ, ,wɜːld? θɹiː,ziəɹoʊziəɹoʊ ziəɹoʊ, ɔːɹ tuː.fɪfti. həloʊ? '),
+         'həloʊ, ,wɜːld? θɹiː θaʊzənd, ɔːɹ tuː pɔɪnt faɪv ziəɹoʊ. həloʊ? '),
         (re.compile(r"[^a-zA-ZÀ-ÖØ-öø-ÿ0-9'$@&+%\-=/\\]"),
          'hello, ,world? ‡ 3,000, or 2.50. ¿hello?',
          'həloʊ, ,wɜːld? ‡ θɹiː,ziəɹoʊziəɹoʊ ziəɹoʊ, ɔːɹ tuː.fɪfti. ¿həloʊ? '),


### PR DESCRIPTION
## The problem

`Punctuation` treats every `,` and `.` as punctuation without looking at context, so a decimal number is split before it reaches the backend. espeak then reads two separate numbers:

| text | espeak-ng | phonemizer |
|---|---|---|
| `1,5` (nl) | `ˈeːn kˌɔmaː vˌɛɪf` | `ˈeːn vˈɛɪf` |
| `1.5` (en) | `wˈʌn pɔɪnt fˈaɪv` | `wˈʌn fˈaɪv` |
| `3,14` (nl) | `drˈi kˌɔmaː ˌeːn vˌir` | `drˈi fˈɪːrtin` |
| `19,99 euro` (nl) | `nˈeːɣəntin kˌɔmaː nˌeːɣən nˌeːɣən ˈøːroː` | `nˈeːɣəntˌin nˈeːɣənɛnnˌeːɡəntəx ˈøːroː` |

The last row is worth singling out: that is not a mispronunciation but a **different amount**. "nineteen comma nine nine" became "nineteen ninety-nine".

`preserve_punctuation=True` does not help — it returns the mark as a literal character rather than letting espeak read it:

```python
>>> phonemize('1,5', language='nl', backend='espeak', preserve_punctuation=True)
'ˈeːn,vˈɛɪf'
```

This affects every language and both separators, so it is not locale- or platform-specific.

## Cause

```python
self._marks_re = re.compile(fr'(\s*[{re.escape(self._marks)}]+\s*)+')
```

Purely character-based, no context, and `,` and `.` are both in `_DEFAULT_MARKS`.

## The fix

Build the regex so a mark that doubles as a decimal separator counts as punctuation only when it is **not** between two digits. Everything else is unchanged:

| input | result | note |
|---|---|---|
| `1,5` | `1,5` | was `1 5` |
| `3.14` | `3.14` | was `3 14` |
| `1,5, and more` | `1,5 and more` | first comma decimal, second punctuation |
| `line 42, column 7` | `line 42 column 7` | unchanged |
| `I have 42.` | `I have 42` | unchanged |
| `hello, world` | `hello world` | unchanged |

Marks that are not decimal separators are untouched, and a custom `re.Pattern` passed to `marks` still takes the existing branch.

## Verification

Across en/nl/de/fr/es/it/pt/ru/cs/el, `phonemize()` output now matches `espeak-ng -q -x --ipa` on decimals: **18/18 cases, previously 2/18**.

`preserve`/`restore` round-trips correctly:

```
'1,5 and more'  -> preserve=['1,5 and more'] -> restore=['1,5 and more']
'hello, world'  -> preserve=['hello', 'world'] -> restore=['hello, world']
```

## Tests

Added to `test/test_punctuation.py`: a parametrised check of the split behaviour (including the mixed case where one comma is a separator and the next is punctuation) and a preserve/restore round-trip.

## Test run notes

Tested on Windows 11, Python 3.12, espeak-ng 1.52.

I could not run `test/test_punctuation.py` itself here — it imports `FestivalBackend` at module level and festival is not installable on Windows, so the module fails to collect regardless of this change. I verified the `Punctuation` behaviour directly against the same cases instead, including all pre-existing ones (ordinary commas, colons, brackets, quotes, ellipses, repeated marks), which all keep their previous output. The espeak suites are unaffected: 54 passed, 1 pre-existing failure (`test_available_voices`, unrelated — see #215).

Worth a look from someone who can run the festival and segments tests, since `Punctuation` is shared by all backends.

## Relation to #214 and #215

Independent of both; different file, different function. #214 makes the library findable on Windows, #215 makes six languages usable, this one fixes decimals everywhere. Happy to rebase whichever lands last.
